### PR TITLE
Validate Opts

### DIFF
--- a/lib/handler/opts.ex
+++ b/lib/handler/opts.ex
@@ -1,0 +1,44 @@
+defmodule Handler.Opts do
+  @moduledoc false
+
+  def bytes_to_words(max_bytes) when is_integer(max_bytes) do
+    div(max_bytes, :erlang.system_info(:wordsize))
+  end
+
+  def max_heap_bytes(opts) do
+    Keyword.get(opts, :max_heap_bytes, 10 * 1024 * 1024)
+  end
+
+  def max_ms(opts) do
+    Keyword.get(opts, :max_ms, 60_000)
+  end
+
+  def validate_handler_opts!([]), do: :ok
+  def validate_handler_opts!(opts) when is_list(opts) do
+    Enum.each(opts, &validate_handler_opt!/1)
+  end
+  def validate_handler_opts!(_other) do
+    raise ArgumentError, "Invalid opts provided, not a list"
+  end
+
+  defp validate_handler_opt!({:max_ms, number}) when is_integer(number) and number > 0, do: :ok
+  defp validate_handler_opt!({:max_heap_bytes, number}) when is_integer(number) and number > 0, do: :ok
+  defp validate_handler_opt!(other) do
+    raise ArgumentError, "Invalid option #{inspect(other)}"
+  end
+
+  def validate_pool_opts!([]), do: :ok
+  def validate_pool_opts!(opts) when is_list(opts) do
+    Enum.each(opts, &validate_pool_opt!/1)
+  end
+  def validate_pool_opts!(_other) do
+    raise ArgumentError, "Invalid opts provided, not a list"
+  end
+
+  defp validate_pool_opt!({:max_ms, number}) when is_integer(number) and number > 0, do: :ok
+  defp validate_pool_opt!({:max_heap_bytes, number}) when is_integer(number) and number > 0, do: :ok
+  defp validate_pool_opt!({:task_name, _name}), do: :ok
+  defp validate_pool_opt!(other) do
+    raise ArgumentError, "Invalid option #{inspect(other)}"
+  end
+end

--- a/lib/handler/opts.ex
+++ b/lib/handler/opts.ex
@@ -18,30 +18,41 @@ defmodule Handler.Opts do
   end
 
   def validate_handler_opts!([]), do: :ok
+
   def validate_handler_opts!(opts) when is_list(opts) do
     Enum.each(opts, &validate_handler_opt!/1)
   end
+
   def validate_handler_opts!(_other) do
     raise ArgumentError, "Invalid opts provided, not a list"
   end
 
   defp validate_handler_opt!({:max_ms, number}) when is_integer(number) and number > 0, do: :ok
-  defp validate_handler_opt!({:max_heap_bytes, number}) when is_integer(number) and number > 0, do: :ok
+
+  defp validate_handler_opt!({:max_heap_bytes, number}) when is_integer(number) and number > 0,
+    do: :ok
+
   defp validate_handler_opt!(other) do
     raise ArgumentError, "Invalid option #{inspect(other)}"
   end
 
   def validate_pool_opts!([]), do: :ok
+
   def validate_pool_opts!(opts) when is_list(opts) do
     Enum.each(opts, &validate_pool_opt!/1)
   end
+
   def validate_pool_opts!(_other) do
     raise ArgumentError, "Invalid opts provided, not a list"
   end
 
   defp validate_pool_opt!({:max_ms, number}) when is_integer(number) and number > 0, do: :ok
-  defp validate_pool_opt!({:max_heap_bytes, number}) when is_integer(number) and number > 0, do: :ok
+
+  defp validate_pool_opt!({:max_heap_bytes, number}) when is_integer(number) and number > 0,
+    do: :ok
+
   defp validate_pool_opt!({:task_name, _name}), do: :ok
+
   defp validate_pool_opt!(other) do
     raise ArgumentError, "Invalid option #{inspect(other)}"
   end

--- a/lib/handler/opts.ex
+++ b/lib/handler/opts.ex
@@ -13,6 +13,10 @@ defmodule Handler.Opts do
     Keyword.get(opts, :max_ms, 60_000)
   end
 
+  def task_name(opts) do
+    Keyword.get(opts, :task_name)
+  end
+
   def validate_handler_opts!([]), do: :ok
   def validate_handler_opts!(opts) when is_list(opts) do
     Enum.each(opts, &validate_handler_opt!/1)

--- a/lib/handler/pool.ex
+++ b/lib/handler/pool.ex
@@ -6,6 +6,7 @@ defmodule Handler.Pool do
 
   alias __MODULE__
   alias Handler.Pool.State
+  import Handler.Opts
   use GenServer
 
   @type t :: %Handler.Pool{
@@ -15,6 +16,8 @@ defmodule Handler.Pool do
           name: nil | name()
         }
   @type name :: GenServer.name()
+  @type opts :: list(opt())
+  @type opt :: Handler.opt() | {:task_name, String.t()}
   @type pool :: GenServer.server()
   @type exception :: Pool.InsufficientMemory.t() | Pool.NoWorkersAvailable.t()
 
@@ -52,8 +55,9 @@ defmodule Handler.Pool do
   a reference you can pass to the `await/1` function, or a reject tuple with an exception describing
   why the function couldn't be started.
   """
-  @spec async(pool(), (() -> any()), Handler.opts()) :: {:ok, reference()} | {:reject, exception}
+  @spec async(pool(), (() -> any()), opts()) :: {:ok, reference()} | {:reject, exception}
   def async(pool, fun, opts) do
+    validate_pool_opts!(opts)
     GenServer.call(pool, {:run, fun, opts}, 1_000)
   end
 
@@ -72,9 +76,10 @@ defmodule Handler.Pool do
   the addition of the `{:reject, t:exception()}` return values when the pool
   does not have enough resources to start a particular function.
   """
-  @spec run(pool(), (() -> any()), Handler.opts()) ::
+  @spec run(pool(), (() -> any()), opts()) ::
           any() | {:error, Handler.exception()} | {:reject, exception()}
   def run(pool, fun, opts) do
+    validate_pool_opts!(opts)
     with {:ok, ref} <- async(pool, fun, opts) do
       await(ref)
     end
@@ -89,6 +94,7 @@ defmodule Handler.Pool do
 
   ## GenServer / OTP callbacks
 
+  @spec start_link(Handler.Pool.t()) :: :ignore | {:error, any} | {:ok, pid}
   def start_link(%Pool{name: name} = config) when not is_nil(name) do
     opts = [name: name]
     GenServer.start_link(Pool, config, opts)

--- a/lib/handler/pool.ex
+++ b/lib/handler/pool.ex
@@ -80,6 +80,7 @@ defmodule Handler.Pool do
           any() | {:error, Handler.exception()} | {:reject, exception()}
   def run(pool, fun, opts) do
     validate_pool_opts!(opts)
+
     with {:ok, ref} <- async(pool, fun, opts) do
       await(ref)
     end

--- a/lib/handler/pool/state.ex
+++ b/lib/handler/pool/state.ex
@@ -3,6 +3,7 @@ defmodule Handler.Pool.State do
   alias __MODULE__
   alias Handler.Pool
   alias Handler.Pool.{InsufficientMemory, NoWorkersAvailable}
+  import Handler.Opts
 
   defstruct running_workers: 0,
             bytes_committed: 0,
@@ -52,7 +53,7 @@ defmodule Handler.Pool.State do
   @spec start_worker(t(), fun, keyword(), pid()) ::
           {:ok, t(), reference()} | {:reject, exception()}
   def start_worker(state, fun, opts, from_pid) do
-    bytes_requested = Handler.max_heap_bytes(opts)
+    bytes_requested = max_heap_bytes(opts)
     task_name = Keyword.get(opts, :task_name)
 
     with :ok <- check_committed_resources(state, bytes_requested),

--- a/lib/handler/pool/state.ex
+++ b/lib/handler/pool/state.ex
@@ -50,15 +50,14 @@ defmodule Handler.Pool.State do
   Try to start a job on a worker from the pool. If there is not enough
   memory or all the workers are busy, return `{:reject, t:exception()}`.
   """
-  @spec start_worker(t(), fun, keyword(), pid()) ::
+  @spec start_worker(t(), fun, Pool.opts(), pid()) ::
           {:ok, t(), reference()} | {:reject, exception()}
   def start_worker(state, fun, opts, from_pid) do
     bytes_requested = max_heap_bytes(opts)
-    task_name = Keyword.get(opts, :task_name)
 
     with :ok <- check_committed_resources(state, bytes_requested),
          {:ok, ref, task_pid} <- kickoff_new_task(state, fun, opts) do
-      new_state = commit_resources(state, ref, bytes_requested, from_pid, task_pid, task_name)
+      new_state = commit_resources(state, ref, bytes_requested, from_pid, task_pid, task_name(opts))
       {:ok, new_state, ref}
     end
   end

--- a/lib/handler/pool/state.ex
+++ b/lib/handler/pool/state.ex
@@ -54,10 +54,12 @@ defmodule Handler.Pool.State do
           {:ok, t(), reference()} | {:reject, exception()}
   def start_worker(state, fun, opts, from_pid) do
     bytes_requested = max_heap_bytes(opts)
+    name = task_name(opts)
 
     with :ok <- check_committed_resources(state, bytes_requested),
          {:ok, ref, task_pid} <- kickoff_new_task(state, fun, opts) do
-      new_state = commit_resources(state, ref, bytes_requested, from_pid, task_pid, task_name(opts))
+      new_state = commit_resources(state, ref, bytes_requested, from_pid, task_pid, name)
+
       {:ok, new_state, ref}
     end
   end

--- a/test/handler/pool_test.exs
+++ b/test/handler/pool_test.exs
@@ -311,13 +311,13 @@ defmodule Handler.PoolTest do
 
     test "an unexpected tuple raises an error" do
       assert_raise(ArgumentError, fn ->
-        Pool.run(:fake_pool, fn -> true end, [max_time: 100])
+        Pool.run(:fake_pool, fn -> true end, max_time: 100)
       end)
     end
 
     test "a tuple with an invalid value raises an error" do
       assert_raise(ArgumentError, fn ->
-        Pool.run(:fake_pool, fn -> true end, [max_heap_bytes: "However much I want"])
+        Pool.run(:fake_pool, fn -> true end, max_heap_bytes: "However much I want")
       end)
     end
 

--- a/test/handler/pool_test.exs
+++ b/test/handler/pool_test.exs
@@ -302,6 +302,32 @@ defmodule Handler.PoolTest do
     end
   end
 
+  describe "validating opts" do
+    test "opts must be passed as a list" do
+      assert_raise(ArgumentError, fn ->
+        Pool.run(:fake_pool, fn -> true end, false)
+      end)
+    end
+
+    test "an unexpected tuple raises an error" do
+      assert_raise(ArgumentError, fn ->
+        Pool.run(:fake_pool, fn -> true end, [max_time: 100])
+      end)
+    end
+
+    test "a tuple with an invalid value raises an error" do
+      assert_raise(ArgumentError, fn ->
+        Pool.run(:fake_pool, fn -> true end, [max_heap_bytes: "However much I want"])
+      end)
+    end
+
+    test "a non-tuple in the opt list raises and error" do
+      assert_raise(ArgumentError, fn ->
+        Pool.run(:fake_pool, fn -> true end, [nil])
+      end)
+    end
+  end
+
   defp setup_composed_pools do
     {:ok, root} =
       Pool.start_link(%Pool{

--- a/test/handler_test.exs
+++ b/test/handler_test.exs
@@ -32,6 +32,32 @@ defmodule HandlerTest do
     assert exception.__struct__ == Handler.Timeout
   end
 
+  describe "validating opts" do
+    test "opts that are not a list raise an error" do
+      assert_raise(ArgumentError, fn ->
+        Handler.run(fn -> true end, %{})
+      end)
+    end
+
+    test "an unexpected tuple raises an error" do
+      assert_raise(ArgumentError, fn ->
+        Handler.run(fn -> true end, [max_time: 200])
+      end)
+    end
+
+    test "a tuple with an invalid value" do
+      assert_raise(ArgumentError, fn ->
+        Handler.run(fn -> true end, [max_ms: "foobar"])
+      end)
+    end
+
+    test "a non-tuple in the opts list" do
+      assert_raise(ArgumentError, fn ->
+        Handler.run(fn -> true end, [:hi])
+      end)
+    end
+  end
+
   defp build_big_map do
     Enum.reduce(1..1_000_000, %{}, fn i, map ->
       Map.put(map, i, "string #{i}")

--- a/test/handler_test.exs
+++ b/test/handler_test.exs
@@ -41,13 +41,13 @@ defmodule HandlerTest do
 
     test "an unexpected tuple raises an error" do
       assert_raise(ArgumentError, fn ->
-        Handler.run(fn -> true end, [max_time: 200])
+        Handler.run(fn -> true end, max_time: 200)
       end)
     end
 
     test "a tuple with an invalid value" do
       assert_raise(ArgumentError, fn ->
-        Handler.run(fn -> true end, [max_ms: "foobar"])
+        Handler.run(fn -> true end, max_ms: "foobar")
       end)
     end
 


### PR DESCRIPTION
In #4 @marcelloma caught a typo where I was passing the wrong option name in one of our tests (see https://github.com/SpiffInc/handler/pull/4/files#r793676340)

This PR aims to clean this up as well as providing better typespecs around our options. For instance, the options accepted by `Handler` are slightly different than the ones accepted by `Pool` (ie the `task_name`), so it's helpful to document those as two separate types and I broke out all of the option handling code to its own module as well.