### PR TITLE
Dynamic Composed Pools

### DIFF
--- a/lib/handler/opts.ex
+++ b/lib/handler/opts.ex
@@ -46,6 +46,8 @@ defmodule Handler.Opts do
     raise ArgumentError, "Invalid opts provided, not a list"
   end
 
+  defp validate_pool_opt!({:delegate_param, _term}), do: :ok
+
   defp validate_pool_opt!({:max_ms, number}) when is_integer(number) and number > 0, do: :ok
 
   defp validate_pool_opt!({:max_heap_bytes, number}) when is_integer(number) and number > 0,

--- a/lib/handler/pool.ex
+++ b/lib/handler/pool.ex
@@ -1,5 +1,6 @@
 defmodule Handler.Pool do
-  defstruct delegate_to: nil,
+  defstruct delegate_fun: nil,
+            delegate_to: nil,
             max_workers: 100,
             max_memory_bytes: 10 * 1024 * 1024 * 1024,
             name: nil
@@ -10,6 +11,7 @@ defmodule Handler.Pool do
   use GenServer
 
   @type t :: %Handler.Pool{
+          delegate_fun: nil | {atom(), atom(), term()},
           delegate_to: nil | name(),
           max_workers: non_neg_integer(),
           max_memory_bytes: non_neg_integer(),
@@ -17,7 +19,7 @@ defmodule Handler.Pool do
         }
   @type name :: GenServer.name()
   @type opts :: list(opt())
-  @type opt :: Handler.opt() | {:task_name, String.t()}
+  @type opt :: Handler.opt() | {:task_name, String.t()} | {:delegate_param, term()}
   @type pool :: GenServer.server()
   @type exception :: Pool.InsufficientMemory.t() | Pool.NoWorkersAvailable.t()
 

--- a/lib/handler/pool/state.ex
+++ b/lib/handler/pool/state.ex
@@ -126,7 +126,8 @@ defmodule Handler.Pool.State do
     param = Keyword.get(opts, :delegate_param)
     pools = apply(mod, fun_name, [config, param])
     acc = {:reject, NoWorkersAvailable.exception(message: "No Pools Available")}
-    Enum.reduce_while(pools, acc, fn(pool, _acc) ->
+
+    Enum.reduce_while(pools, acc, fn pool, _acc ->
       case Pool.async(pool, fun, opts) do
         {:ok, ref} ->
           {:halt, {:ok, ref, nil}}

--- a/test/handler/pool_test.exs
+++ b/test/handler/pool_test.exs
@@ -302,6 +302,54 @@ defmodule Handler.PoolTest do
     end
   end
 
+  describe "dynamic composed pools" do
+    test "jobs execute in one of the root pools" do
+      {_even_root, _odd_root, child} = setup_dynamic_composed_pools()
+
+      assert :ok = Pool.run(child, fn -> :ok end, max_heap_bytes: 10 * 1024, delegate_param: 2)
+      assert :ok = Pool.run(child, fn -> :ok end, max_heap_bytes: 10 * 1024, delegate_param: 1)
+    end
+
+    test "jobs run in their corresponding root pools" do
+      {even_root, odd_root, child} = setup_dynamic_composed_pools()
+      fun = fn -> :timer.sleep(10_000) end
+
+      assert {:ok, even_ref} = Pool.async(child, fun, [max_heap_bytes: 10 * 1024, delegate_param: 4])
+      assert {:ok, odd_ref} = Pool.async(child, fun, [max_heap_bytes: 10 * 1024, delegate_param: 5])
+
+      assert %{workers: child_workers} = :sys.get_state(child)
+      assert %{workers: even_workers} = :sys.get_state(even_root)
+      assert %{workers: odd_workers} = :sys.get_state(odd_root)
+
+      # child has both jobs
+      assert Map.has_key?(child_workers, even_ref)
+      assert Map.has_key?(child_workers, odd_ref)
+
+      # even root has only even job
+      assert Map.has_key?(even_workers, even_ref)
+      refute Map.has_key?(even_workers, odd_ref)
+
+      # odd root has only odd job
+      refute Map.has_key?(odd_workers, even_ref)
+      assert Map.has_key?(odd_workers, odd_ref)
+    end
+
+    test "jobs will attempt all available pools until they find a match" do
+      {_even_root, _odd_root, child} = setup_dynamic_composed_pools()
+      fun = fn -> :timer.sleep(10_000) end
+      opts = [max_heap_bytes: 10 * 1024, delegate_param: :all]
+
+      # there are 2 root pools each with 20kb of space
+      # so we can start 4 jobs before they are both full
+      assert {:ok, _ref} = Pool.async(child, fun, opts)
+      assert {:ok, _ref} = Pool.async(child, fun, opts)
+      assert {:ok, _ref} = Pool.async(child, fun, opts)
+      assert {:ok, _ref} = Pool.async(child, fun, opts)
+      assert {:reject, exception} = Pool.async(child, fun, opts)
+      assert exception == %Pool.NoWorkersAvailable{message: "No workers available"}
+    end
+  end
+
   describe "validating opts" do
     test "opts must be passed as a list" do
       assert_raise(ArgumentError, fn ->
@@ -326,6 +374,41 @@ defmodule Handler.PoolTest do
         Pool.run(:fake_pool, fn -> true end, [nil])
       end)
     end
+  end
+
+  # This is a simplistic example of dynamically composing pools
+  # we expect two potential parent pools for our config and then
+  # our param will be an integer so we can send them to either the
+  # even or odd parent pool
+  defmodule EvenOddBalance do
+    def filter(pools, :all) do
+      pools
+    end
+
+    def filter([even, odd], param) do
+      case rem(param, 2) do
+        0 -> [even]
+        1 -> [odd]
+      end
+    end
+  end
+
+  defp setup_dynamic_composed_pools do
+    {:ok, even_root} = Pool.start_link(%Pool{
+      max_workers: 2,
+      max_memory_bytes: 20 * 1024
+    })
+    {:ok, odd_root} = Pool.start_link(%Pool{
+      max_workers: 2,
+      max_memory_bytes: 20 * 1024
+    })
+    {:ok, child} = Pool.start_link(%Pool{
+      max_workers: 4,
+      max_memory_bytes: 40 * 1024,
+      delegate_fun: {EvenOddBalance, :filter, [even_root, odd_root]}
+    })
+
+    {even_root, odd_root, child}
   end
 
   defp setup_composed_pools do

--- a/test/handler/pool_test.exs
+++ b/test/handler/pool_test.exs
@@ -314,8 +314,10 @@ defmodule Handler.PoolTest do
       {even_root, odd_root, child} = setup_dynamic_composed_pools()
       fun = fn -> :timer.sleep(10_000) end
 
-      assert {:ok, even_ref} = Pool.async(child, fun, [max_heap_bytes: 10 * 1024, delegate_param: 4])
-      assert {:ok, odd_ref} = Pool.async(child, fun, [max_heap_bytes: 10 * 1024, delegate_param: 5])
+      assert {:ok, even_ref} =
+               Pool.async(child, fun, max_heap_bytes: 10 * 1024, delegate_param: 4)
+
+      assert {:ok, odd_ref} = Pool.async(child, fun, max_heap_bytes: 10 * 1024, delegate_param: 5)
 
       assert %{workers: child_workers} = :sys.get_state(child)
       assert %{workers: even_workers} = :sys.get_state(even_root)
@@ -394,19 +396,24 @@ defmodule Handler.PoolTest do
   end
 
   defp setup_dynamic_composed_pools do
-    {:ok, even_root} = Pool.start_link(%Pool{
-      max_workers: 2,
-      max_memory_bytes: 20 * 1024
-    })
-    {:ok, odd_root} = Pool.start_link(%Pool{
-      max_workers: 2,
-      max_memory_bytes: 20 * 1024
-    })
-    {:ok, child} = Pool.start_link(%Pool{
-      max_workers: 4,
-      max_memory_bytes: 40 * 1024,
-      delegate_fun: {EvenOddBalance, :filter, [even_root, odd_root]}
-    })
+    {:ok, even_root} =
+      Pool.start_link(%Pool{
+        max_workers: 2,
+        max_memory_bytes: 20 * 1024
+      })
+
+    {:ok, odd_root} =
+      Pool.start_link(%Pool{
+        max_workers: 2,
+        max_memory_bytes: 20 * 1024
+      })
+
+    {:ok, child} =
+      Pool.start_link(%Pool{
+        max_workers: 4,
+        max_memory_bytes: 40 * 1024,
+        delegate_fun: {EvenOddBalance, :filter, [even_root, odd_root]}
+      })
 
     {even_root, odd_root, child}
   end


### PR DESCRIPTION
We have a use-case where we want to have a single customer pool that can optionally schedule work on multiple different servers. We will have an affinity to some servers which have good locality to the data we need, but we can also allow some jobs to be schedule to resource pools on other servers. This means we'll have a single Pool which can delegate work to several different upstream pools

<img width="735" alt="Screenshot 2022-02-11 at 14 32 56" src="https://user-images.githubusercontent.com/80008/153610321-2641a883-57be-4d11-9c22-aa1861f83c93.png">

Still TODO

- [] Support for killing tasks that were dispatched dynamically
- [] Some documentation writeup about the use-case and how to configure it