### PR TITLE
Record workers as maps

### DIFF
--- a/lib/handler.ex
+++ b/lib/handler.ex
@@ -54,12 +54,6 @@ defmodule Handler do
         Process.demonitor(ref, [:flush])
         result
 
-      {Handler.Pool, :user_killed} ->
-        Process.demonitor(ref, [:flush])
-        Task.shutdown(task, :brutal_kill)
-        message = "User killed the process"
-        {:error, ProcessExit.exception(message: message, reason: :user_killed)}
-
       {:DOWN, ^ref, :process, ^pid, :killed} ->
         Process.demonitor(ref, [:flush])
         message = "Process tried to use more than #{max_heap_bytes} bytes of memory"

--- a/lib/handler.ex
+++ b/lib/handler.ex
@@ -54,15 +54,16 @@ defmodule Handler do
         Process.demonitor(ref, [:flush])
         result
 
+      {Handler.Pool, :user_killed} ->
+        Process.demonitor(ref, [:flush])
+        Task.shutdown(task, :brutal_kill)
+        message = "User killed the process"
+        {:error, ProcessExit.exception(message: message, reason: :user_killed)}
+
       {:DOWN, ^ref, :process, ^pid, :killed} ->
         Process.demonitor(ref, [:flush])
         message = "Process tried to use more than #{max_heap_bytes} bytes of memory"
         {:error, OOM.exception(message: message)}
-
-      {:DOWN, ^ref, :process, ^pid, :user_killed} ->
-        Process.demonitor(ref, [:flush])
-        message = "User killed the process"
-        {:error, ProcessExit.exception(message: message, reason: :user_killed)}
 
       {:DOWN, ^ref, :process, ^pid, {header, _stacktrace} = reason} ->
         Process.demonitor(ref, [:flush])

--- a/lib/handler/pool.ex
+++ b/lib/handler/pool.ex
@@ -133,7 +133,7 @@ defmodule Handler.Pool do
 
   @impl GenServer
   def handle_call({:kill_ref, ref}, _from, state) do
-    result = State.kill_worker_by_ref(state, ref)
+    {:ok, state, result} = State.kill_worker_by_ref(state, ref)
     {:reply, result, state}
   end
 

--- a/lib/handler/pool/state.ex
+++ b/lib/handler/pool/state.ex
@@ -96,8 +96,8 @@ defmodule Handler.Pool.State do
       %{delegated_to: pool} ->
         Pool.kill_by_ref(pool, ref)
 
-      %{task_pid: pid} ->
-        :ok = Process.send(pid, {Pool, :user_killed}, [])
+      %{task_pid: task_pid} ->
+        :ok = Process.send(task_pid, {Pool, :user_killed}, [])
         :ok
     end
   end

--- a/lib/handler/pool/state.ex
+++ b/lib/handler/pool/state.ex
@@ -22,14 +22,14 @@ defmodule Handler.Pool.State do
   @type local_worker :: %{
           bytes_committed: non_neg_integer(),
           from_pid: pid(),
-          task_pid: pid(),
-          task_name: String.t() | nil
+          task_name: String.t() | nil,
+          task_pid: pid()
         }
   @type delegated_worker :: %{
           bytes_committed: non_neg_integer(),
-          delegated_to: Pool.pool(),
           from_pid: pid(),
-          task_name: String.t() | nil
+          task_name: String.t() | nil,
+          delegated_to: Pool.pool()
         }
 
   @type exception :: %InsufficientMemory{} | %NoWorkersAvailable{}

--- a/lib/handler/pool/state.ex
+++ b/lib/handler/pool/state.ex
@@ -20,17 +20,17 @@ defmodule Handler.Pool.State do
         }
   @type worker :: local_worker() | delegated_worker()
   @type local_worker :: %{
-    bytes_committed: non_neg_integer(),
-    from_pid: pid(),
-    task_pid: pid(),
-    task_name: String.t() | nil
-  }
+          bytes_committed: non_neg_integer(),
+          from_pid: pid(),
+          task_pid: pid(),
+          task_name: String.t() | nil
+        }
   @type delegated_worker :: %{
-    bytes_committed: non_neg_integer(),
-    delegated_to: Pool.pool(),
-    from_pid: pid(),
-    task_name: String.t() | nil
-  }
+          bytes_committed: non_neg_integer(),
+          delegated_to: Pool.pool(),
+          from_pid: pid(),
+          task_name: String.t() | nil
+        }
 
   @type exception :: %InsufficientMemory{} | %NoWorkersAvailable{}
 
@@ -117,10 +117,11 @@ defmodule Handler.Pool.State do
   end
 
   defp kickoff_new_task(
-    %State{pool: %Pool{delegate_to: pool}},
-    fun,
-    opts,
-    from_pid)
+         %State{pool: %Pool{delegate_to: pool}},
+         fun,
+         opts,
+         from_pid
+       )
        when not is_nil(pool) do
     with {:ok, ref} <- Pool.async(pool, fun, opts) do
       worker = %{
@@ -129,6 +130,7 @@ defmodule Handler.Pool.State do
         from_pid: from_pid,
         task_name: task_name(opts)
       }
+
       {:ok, ref, worker}
     end
   end
@@ -146,6 +148,7 @@ defmodule Handler.Pool.State do
       task_pid: pid,
       task_name: task_name(opts)
     }
+
     {:ok, ref, worker}
   end
 

--- a/lib/handler/pool/state.ex
+++ b/lib/handler/pool/state.ex
@@ -14,15 +14,23 @@ defmodule Handler.Pool.State do
           running_workers: non_neg_integer(),
           bytes_committed: non_neg_integer(),
           workers: %{
-            reference() => {
-              bytes_committed :: non_neg_integer(),
-              from_pid :: pid(),
-              task_pid :: pid(),
-              task_name :: String.t()
-            }
+            reference() => worker()
           },
           pool: %Handler.Pool{}
         }
+  @type worker :: local_worker() | delegated_worker()
+  @type local_worker :: %{
+    bytes_committed: non_neg_integer(),
+    from_pid: pid(),
+    task_pid: pid(),
+    task_name: String.t() | nil
+  }
+  @type delegated_worker :: %{
+    bytes_committed: non_neg_integer(),
+    delegated_to: Pool.pool(),
+    from_pid: pid(),
+    task_name: String.t() | nil
+  }
 
   @type exception :: %InsufficientMemory{} | %NoWorkersAvailable{}
 
@@ -54,51 +62,42 @@ defmodule Handler.Pool.State do
           {:ok, t(), reference()} | {:reject, exception()}
   def start_worker(state, fun, opts, from_pid) do
     bytes_requested = max_heap_bytes(opts)
-    name = task_name(opts)
 
     with :ok <- check_committed_resources(state, bytes_requested),
          {:ok, ref, task_pid} <- kickoff_new_task(state, fun, opts) do
-      new_state = commit_resources(state, ref, bytes_requested, from_pid, task_pid, name)
-
+      new_state = commit_resources(state, ref, bytes_requested, from_pid, task_pid)
       {:ok, new_state, ref}
     end
   end
 
-  def kill_worker(%State{pool: %Pool{delegate_to: pool}} = state, task_name)
-      when not is_nil(pool) do
-    if has_worker_named(state, task_name) do
-      {:ok, number_killed} = Pool.kill(pool, task_name)
-      {:ok, number_killed, state}
-    else
-      {:ok, 0, state}
-    end
+  def kill_worker(state, task_name) do
+    Enum.reduce(state.workers, {:ok, state, 0}, fn
+      {_ref, %{task_pid: task_pid, task_name: ^task_name}}, {:ok, state, number_killed} ->
+        Process.exit(task_pid, :user_killed)
+        {:ok, state, number_killed + 1}
+
+      {ref, %{delegated_to: pool, task_name: ^task_name}}, {:ok, state, number_killed} ->
+        case Pool.kill_by_ref(pool, ref) do
+          :ok ->
+            {:ok, state, number_killed + 1}
+
+          :no_such_worker ->
+            {:ok, state, number_killed}
+        end
+
+      {_ref, _worker}, {:ok, state, number_killed} ->
+        {:ok, state, number_killed}
+    end)
   end
 
-  def kill_worker(state, task_name) do
-    {state, number_killed} =
-      Enum.reduce(state.workers, {state, 0}, fn
-        {ref, {_bytes_commited, _from_pid, task_pid, ^task_name}}, {state, number_killed} ->
-          Process.unlink(task_pid)
-          Process.exit(task_pid, :user_killed)
+  def kill_worker_by_ref(%State{workers: workers}, ref) do
+    case Map.get(workers, ref) do
+      %{delegated_to: pool} ->
+        Pool.kill_by_ref(pool, ref)
 
-          exception =
-            Handler.ProcessExit.exception(
-              message: "User killed the process",
-              reason: :user_killed
-            )
-
-          state =
-            state
-            |> send_response(ref, {:error, exception})
-            |> cleanup_commitments(ref)
-
-          {state, number_killed + 1}
-
-        _other_worker, {state, number_killed} ->
-          {state, number_killed}
-      end)
-
-    {:ok, number_killed, state}
+      %{task_pid: pid} ->
+        Process.exit(pid, :user_killed)
+    end
   end
 
   @spec send_response(t(), reference(), term) :: t()
@@ -115,30 +114,59 @@ defmodule Handler.Pool.State do
     end
   end
 
-  defp kickoff_new_task(%State{pool: %Pool{delegate_to: pool}}, fun, opts)
+  defp kickoff_new_task(
+    %State{pool: %Pool{delegate_to: pool}},
+    fun,
+    opts,
+    bytes_requested,
+    from_pid,
+    task_name)
        when not is_nil(pool) do
     with {:ok, ref} <- Pool.async(pool, fun, opts) do
-      {:ok, ref, nil}
+      worker = %{
+        bytes_committed: bytes_requested,
+        delegated_to: pool,
+        from_pid: from_pid,
+        task_name: task_name(opts)
+      }
+      {:ok, ref, worker}
     end
   end
 
-  defp kickoff_new_task(_state, fun, opts) do
+  defp kickoff_new_task(
+    _state,
+    fun,
+    opts,
+    bytes_requested,
+    from_pid) do
     %Task{ref: ref, pid: pid} =
       Task.async(fn ->
         Handler.run(fun, opts)
       end)
 
-    {:ok, ref, pid}
+    worker = %{
+      bytes_committed: bytes_requested,
+      from_pid: from_pid,
+      task_pid: pid,
+      task_name: task_name(opts)
+    }
+    {:ok, ref, worker}
   end
 
   defp commit_resources(
          %State{workers: workers} = state,
+         state,
          ref,
+         worker,
          bytes_requested,
          from_pid,
-         task_pid,
          task_name
        ) do
+    worker = Map.merge(worker, %{
+      bytes_committed: bytes_requested,
+      from_pid: from_pid,
+      task_name: task_name
+    })
     workers = Map.put(workers, ref, {bytes_requested, from_pid, task_pid, task_name})
 
     %{
@@ -160,12 +188,5 @@ defmodule Handler.Pool.State do
       true ->
         :ok
     end
-  end
-
-  defp has_worker_named(%{workers: workers}, task_name) do
-    Enum.any?(workers, fn
-      {_ref, {_bytes_requested, _from_pid, _task_pid, ^task_name}} -> true
-      _ -> false
-    end)
   end
 end

--- a/test/handler/pool_test.exs
+++ b/test/handler/pool_test.exs
@@ -204,10 +204,12 @@ defmodule Handler.PoolTest do
 
     assert {:ok, 1} = Pool.kill(pool, task_name)
     assert {:error, error} = Pool.await(ref)
+
     assert error == %Handler.ProcessExit{
-      message: "User killed the process",
-      reason: :user_killed
-    }
+             message: "User killed the process",
+             reason: :user_killed
+           }
+
     assert %{workers: workers} = :sys.get_state(pool)
     assert Enum.empty?(workers)
     assert {:ok, 0} = Pool.kill(pool, task_name)
@@ -278,7 +280,12 @@ defmodule Handler.PoolTest do
 
       {:ok, 1} = Pool.kill(composed, task_name)
       assert {:error, exception} = Pool.await(ref)
-      assert exception == %Handler.ProcessExit{reason: :user_killed, message: "User killed the process"}
+
+      assert exception == %Handler.ProcessExit{
+               reason: :user_killed,
+               message: "User killed the process"
+             }
+
       {:ok, 0} = Pool.kill(composed, task_name)
 
       assert %{workers: %{}} = :sys.get_state(composed)
@@ -289,7 +296,12 @@ defmodule Handler.PoolTest do
 
       {:ok, 1} = Pool.kill(root, task_name)
       assert {:error, exception} = Pool.await(ref)
-      assert exception == %Handler.ProcessExit{reason: :user_killed, message: "User killed the process"}
+
+      assert exception == %Handler.ProcessExit{
+               reason: :user_killed,
+               message: "User killed the process"
+             }
+
       {:ok, 0} = Pool.kill(root, task_name)
 
       assert %{workers: %{}} = :sys.get_state(composed)

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -1,1 +1,1 @@
-ExUnit.start()
+ExUnit.start(timeout: 1_000)


### PR DESCRIPTION
As I was working on #6 I was trying to support killing a worker that had been sent to one of several different delegate pools. It was going to be a lot easier if I could add some optional keys to the worker metadata (ie either have a `task_pid` or a `delegated_to`, but not both). So I decided to create this PR as a "pre-factor".

This PR introduces the change to store workers as maps (either a `local_worker` or a `delegated_worker` map). I also added some typespecs which I found helpful to keep the shape of the state in my head.

As I was making that change I also realized that I could unify the way we kill processes for both local and delegated workers by just pattern matching on whether they had a `task_pid` or a `delegated_to` key. And for the delegated tasks I switched to killing them by their `ref`. This avoids the weird edge cases where we end up killing tasks in the root pool that were actually started through some other child pool. Since `ref`s are guaranteed to be unique by the VM we can treat them as fully unique and just kill the one task we're interested in without having to iterate through all of the workers.

And lastly I switched the process of killing a task so that it sends the kill signal to the task and let's it be killed via the normal process, so we don't have to do special case un-linking and freeing commitments. This also solves an edge case where a task had been delegated through multiple pools and you want all of them to be notified of that process having crashed.