### PR TITLE
Fix untracked reference when killing named task

### DIFF
--- a/lib/handler.ex
+++ b/lib/handler.ex
@@ -59,11 +59,6 @@ defmodule Handler do
         message = "Process tried to use more than #{max_heap_bytes} bytes of memory"
         {:error, OOM.exception(message: message)}
 
-      {:DOWN, ^ref, :process, ^pid, :user_killed} ->
-        Process.demonitor(ref, [:flush])
-        message = "User killed the process"
-        {:error, ProcessExit.exception(message: message, reason: :user_killed)}
-
       {:DOWN, ^ref, :process, ^pid, {header, _stacktrace} = reason} ->
         Process.demonitor(ref, [:flush])
         message = "Process exited with #{inspect(header)}"

--- a/lib/handler/pool/state.ex
+++ b/lib/handler/pool/state.ex
@@ -124,6 +124,7 @@ defmodule Handler.Pool.State do
   defp kickoff_new_task(_state, fun, opts) do
     %Task{ref: ref, pid: pid} =
       Task.async(fn ->
+        opts = Keyword.delete(opts, :task_name)
         Handler.run(fun, opts)
       end)
 

--- a/lib/handler/pool/state.ex
+++ b/lib/handler/pool/state.ex
@@ -78,8 +78,7 @@ defmodule Handler.Pool.State do
     {state, number_killed} =
       Enum.reduce(state.workers, {state, 0}, fn
         {ref, {_bytes_commited, _from_pid, task_pid, ^task_name}}, {state, number_killed} ->
-          Process.unlink(task_pid)
-          Process.exit(task_pid, :user_killed)
+          Task.shutdown(%Task{ref: ref, pid: task_pid, owner: self()}, :brutal_kill)
 
           exception =
             Handler.ProcessExit.exception(


### PR DESCRIPTION
While integrating this with existent functionality we run into the scenario where the `Task` "holding" the function execution was being killed but the associated function execution was not killed, leading to a weird scenario where we had this

<img width="764" alt="image" src="https://user-images.githubusercontent.com/8870712/154717149-90f2e530-9d95-437a-acc2-0df8b6747bee.png">


This handles the killing by executing the `Task.shutdown` on the given `Task` structure, also the option passed as `:task_name` was deleted prior to the `Handler.run` execution in order to avoid a validation error because of this. Last but not least pattern matching for `:user_killed` was deleted as it is not handled bt the `Handler` , it is fact handled by  `Pool.await`

Thanks @marcelloma for the help!

