### PR TITLE
Jonner/pool not available

### DIFF
--- a/lib/handler/pool.ex
+++ b/lib/handler/pool.ex
@@ -70,7 +70,7 @@ defmodule Handler.Pool do
       GenServer.call(pool, {:run, fun, opts}, 1_000)
     catch
       :exit, {:noproc, _} ->
-        {:reject, NoWorkersAvailable.exception(message: "Pool not available")}
+        {:reject, NoWorkersAvailable.exception(message: "No Pools Available")}
     end
   end
 


### PR DESCRIPTION
Handles the case where we refer to a pool which is not available right now (ie a name not registered or a pid that has died etc)