### PR TITLE
handle GenServer.call timeouts and provide an option for the timeout

### DIFF
--- a/lib/handler/opts.ex
+++ b/lib/handler/opts.ex
@@ -53,6 +53,8 @@ defmodule Handler.Opts do
   defp validate_pool_opt!({:max_heap_bytes, number}) when is_integer(number) and number > 0,
     do: :ok
 
+  defp validate_pool_opt!({:pool_timeout, number}) when is_integer(number) and number > 0, do: :ok
+
   defp validate_pool_opt!({:task_name, _name}), do: :ok
 
   defp validate_pool_opt!(other) do

--- a/lib/handler/pool/exceptions.ex
+++ b/lib/handler/pool/exceptions.ex
@@ -7,3 +7,8 @@ defmodule Handler.Pool.InsufficientMemory do
   @type t :: %__MODULE__{}
   defexception [:message]
 end
+
+defmodule Handler.Pool.Timeout do
+  @type t :: %__MODULE__{}
+  defexception [:message]
+end

--- a/lib/handler/pool/state.ex
+++ b/lib/handler/pool/state.ex
@@ -187,7 +187,7 @@ defmodule Handler.Pool.State do
   defp kickoff_new_task(_state, fun, opts, from_pid) do
     task =
       Task.async(fn ->
-        task_opts = Keyword.drop(opts, [:delegate_param, :task_name])
+        task_opts = Keyword.drop(opts, [:delegate_param, :task_name, :pool_timeout])
         Handler.run(fun, task_opts)
       end)
 


### PR DESCRIPTION
We have run into some cases where the peg nodes get very busy on CPU and we miss the 1sec timeout for calling the pool. This is not ideal, but right now it turns into a process exit where it would be a lot better to return a `{:reject, exception}`.

This PR adds a `pool_timeout: 5_000` option and also catches timeout exits to transform it into an exception with a specific type.